### PR TITLE
Validate the config file using `rsyslogd -N 1` whenever a config change is made

### DIFF
--- a/providers/file_input.rb
+++ b/providers/file_input.rb
@@ -28,6 +28,7 @@ action :create do
               'state_file' => new_resource.name,
               'severity' => new_resource.severity,
               'facility' => new_resource.facility
+    notifies :run, 'execute[validate_config]'
     notifies :restart, resources(:service => 'rsyslog')
   end
 end

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -62,11 +62,13 @@ template "#{node['rsyslog']['config_prefix']}/rsyslog.d/49-remote.conf" do
   group     'root'
   mode      '0644'
   variables(:servers => rsyslog_servers)
+  notifies  :run, 'execute[validate_config]'
   notifies  :restart, "service[#{node['rsyslog']['service_name']}]"
   only_if   { node['rsyslog']['remote_logs'] }
 end
 
 file "#{node['rsyslog']['config_prefix']}/rsyslog.d/server.conf" do
   action   :delete
+  notifies :run, 'execute[validate_config]'
   notifies :restart, "service[#{node['rsyslog']['service_name']}]"
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -37,6 +37,11 @@ directory node['rsyslog']['working_dir']  do
   mode  '0700'
 end
 
+execute 'validate_config' do
+  command "rsyslogd -N 1 -f #{node['rsyslog']['config_prefix']}/rsyslog.conf"
+  action  :nothing
+end
+
 # Our main stub which then does its own rsyslog-specific
 # include of things in /etc/rsyslog.d/*
 template "#{node['rsyslog']['config_prefix']}/rsyslog.conf" do
@@ -44,6 +49,7 @@ template "#{node['rsyslog']['config_prefix']}/rsyslog.conf" do
   owner   'root'
   group   'root'
   mode    '0644'
+  notifies :run, 'execute[validate_config]'
   notifies :restart, "service[#{node['rsyslog']['service_name']}]"
 end
 
@@ -52,6 +58,7 @@ template "#{node['rsyslog']['config_prefix']}/rsyslog.d/50-default.conf" do
   owner   'root'
   group   'root'
   mode    '0644'
+  notifies :run, 'execute[validate_config]'
   notifies :restart, "service[#{node['rsyslog']['service_name']}]"
 end
 

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -34,11 +34,13 @@ template "#{node['rsyslog']['config_prefix']}/rsyslog.d/35-server-per-host.conf"
   owner    'root'
   group    'root'
   mode     '0644'
+  notifies :run, 'execute[validate_config]'
   notifies :restart, "service[#{node['rsyslog']['service_name']}]"
 end
 
 file "#{node['rsyslog']['config_prefix']}/rsyslog.d/remote.conf" do
   action   :delete
+  notifies :run, 'execute[validate_config]'
   notifies :restart, "service[#{node['rsyslog']['service_name']}]"
   only_if  { ::File.exist?("#{node['rsyslog']['config_prefix']}/rsyslog.d/remote.conf") }
 end


### PR DESCRIPTION
Right now if an error is made somewhere in the configuration, rsyslog fails silently on restart. This should cause it to throw an error on convergence.

**Potential pitfall:** Validation is only performed on file update, but the update happens regardless of whether the validation succeeds. Consequently the convergence will only fail the *first* time after an error is introduced. Thoughts?