### PR TITLE
relp forwarding should honor logs_to_forward

### DIFF
--- a/templates/default/49-relp.conf.erb
+++ b/templates/default/49-relp.conf.erb
@@ -6,5 +6,5 @@ $ActionResumeRetryCount -1 # infinite retries on insert failure
 $ActionQueueSaveOnShutdown on # save in-memory data if rsyslog shuts down
 
 <% @servers.each do |server| -%>
-*.* :omrelp:<%= "#{server}:#{node['rsyslog']['relp_port']}" %><%= node['rsyslog']['default_remote_template'] ? ';' + node['rsyslog']['default_remote_template'] : nil %>
+<%= node['rsyslog']['logs_to_forward'] %> :omrelp:<%= "#{server}:#{node['rsyslog']['relp_port']}" %><%= node['rsyslog']['default_remote_template'] ? ';' + node['rsyslog']['default_remote_template'] : nil %>
 <% end -%>


### PR DESCRIPTION
The `49-relp.conf` wasn't honoring the `logs_to_forward` node attribute
and was therefor forwarding everything.