### PR TITLE
if there are no remote syslog servers, just do local config

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Installs and configures rsyslog'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '2.1.2'
+version           '2.1.1'
 
 recipe            'rsyslog', 'Installs rsyslog'
 recipe            'rsyslog::client', 'Sets up a client to log to a remote rsyslog server'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Installs and configures rsyslog'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '2.1.1'
+version           '2.1.2'
 
 recipe            'rsyslog', 'Installs rsyslog'
 recipe            'rsyslog::client', 'Sets up a client to log to a remote rsyslog server'

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -77,6 +77,8 @@ if !rsyslog_servers.empty?
     notifies  :restart, "service[#{node['rsyslog']['service_name']}]"
     only_if   { node['rsyslog']['remote_logs'] }
   end
+else
+  Chef::Log.warn('The rsyslog::client recipe was unable to determine the remote syslog server. Checked both the server_ip attribute and search! Not forwarding logs.')
 end
 
 file "#{node['rsyslog']['config_prefix']}/rsyslog.d/server.conf" do

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -65,20 +65,18 @@ unless node['rsyslog']['custom_remote'].first.empty?
   rsyslog_servers += node['rsyslog']['custom_remote']
 end
 
-if rsyslog_servers.empty?
-  Chef::Application.fatal!('The rsyslog::client recipe was unable to determine the remote syslog server. Checked both the server_ip attribute and search!')
-end
+if !rsyslog_servers.empty?
+  remote_type = node['rsyslog']['use_relp'] ? 'relp' : 'remote'
 
-remote_type = node['rsyslog']['use_relp'] ? 'relp' : 'remote'
-
-template "#{node['rsyslog']['config_prefix']}/rsyslog.d/49-remote.conf" do
-  source    "49-#{remote_type}.conf.erb"
-  owner     'root'
-  group     'root'
-  mode      '0644'
-  variables(servers: rsyslog_servers)
-  notifies  :restart, "service[#{node['rsyslog']['service_name']}]"
-  only_if   { node['rsyslog']['remote_logs'] }
+  template "#{node['rsyslog']['config_prefix']}/rsyslog.d/49-remote.conf" do
+    source    "49-#{remote_type}.conf.erb"
+    owner     'root'
+    group     'root'
+    mode      '0644'
+    variables(servers: rsyslog_servers)
+    notifies  :restart, "service[#{node['rsyslog']['service_name']}]"
+    only_if   { node['rsyslog']['remote_logs'] }
+  end
 end
 
 file "#{node['rsyslog']['config_prefix']}/rsyslog.d/server.conf" do

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -65,7 +65,9 @@ unless node['rsyslog']['custom_remote'].first.empty?
   rsyslog_servers += node['rsyslog']['custom_remote']
 end
 
-if !rsyslog_servers.empty?
+if rsyslog_servers.empty?
+  Chef::Log.warn('The rsyslog::client recipe was unable to determine the remote syslog server. Checked both the server_ip attribute and search! Not forwarding logs.')
+else
   remote_type = node['rsyslog']['use_relp'] ? 'relp' : 'remote'
 
   template "#{node['rsyslog']['config_prefix']}/rsyslog.d/49-remote.conf" do
@@ -77,8 +79,6 @@ if !rsyslog_servers.empty?
     notifies  :restart, "service[#{node['rsyslog']['service_name']}]"
     only_if   { node['rsyslog']['remote_logs'] }
   end
-else
-  Chef::Log.warn('The rsyslog::client recipe was unable to determine the remote syslog server. Checked both the server_ip attribute and search! Not forwarding logs.')
 end
 
 file "#{node['rsyslog']['config_prefix']}/rsyslog.d/server.conf" do


### PR DESCRIPTION
do not break if your not using remote syslog hosts, just don't write a config file for remote servers.
so you can still use the cookbook to manage your local config or if you have not yet created any syslog servers in your environment yet.