### PR TITLE
file_input configured InputFileTag and InputFileStateFile with a path

### DIFF
--- a/resources/file_input.rb
+++ b/resources/file_input.rb
@@ -27,6 +27,7 @@ property :cookbook_source, String, default: 'rsyslog'
 property :template_source, String, default: 'file-input.conf.erb'
 
 action :create do
+  log_name = name
   template "/etc/rsyslog.d/#{priority}-#{name}.conf" do
     mode '0664'
     owner node['rsyslog']['user']
@@ -34,8 +35,8 @@ action :create do
     source template_source
     cookbook cookbook_source
     variables 'file_name' => file,
-              'tag' => name,
-              'state_file' => name,
+              'tag' => log_name,
+              'state_file' => log_name,
               'severity' => severity,
               'facility' => facility
     notifies :restart, "service[#{node['rsyslog']['service_name']}]"

--- a/test/integration/input_file_provider/serverspec/input_file_provider_spec.rb
+++ b/test/integration/input_file_provider/serverspec/input_file_provider_spec.rb
@@ -11,3 +11,11 @@ end
 describe file('/etc/rsyslog.d/99-test-file.conf') do
   its(:content) { should match /InputFileName \/var\/log\/boot/ }
 end
+
+describe file('/etc/rsyslog.d/99-test-file.conf') do
+  its(:content) { should match /InputFileTag test-file/ }
+end
+
+describe file('/etc/rsyslog.d/99-test-file.conf') do
+  its(:content) { should match /InputFileStateFile test-file/ }
+end


### PR DESCRIPTION
The name variable is reassigned within the file_input resource inside the template resource to be the file path of the configuration file. This causes InputFileTag and InputFileStateFile to be configured with a path to the configuration file and not the name of the rsyslog_file_input resource as I believe was probably the intention.


Tests for the broken behaviour are in a separate commit. 
