### PR TITLE
use correct filename for remote.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Any previous logs are not cleaned up from the `log_dir`.
 ### server
 Configures the node to be a rsyslog server. The chosen rsyslog server node should be defined in the `server_ip` attribute or resolvable by the specified search criteria specified in `node['rsyslog']['server_search]` (so that nodes making use of the `client` recipe can find the server to log to).
 
-This recipe will create the logs in `node['rsyslog']['log_dir']`, and the configuration is in `/etc/rsyslog.d/server.conf`. This recipe also removes any previous configuration to a remote server by removing the `/etc/rsyslog.d/remote.conf` file.
+This recipe will create the logs in `node['rsyslog']['log_dir']`, and the configuration is in `/etc/rsyslog.d/server.conf`. This recipe also removes any previous configuration to a remote server by removing the `/etc/rsyslog.d/49-remote.conf` file.
 
 The cron job used in the previous version of this cookbook is removed, but it does not remove any existing cron job from your system (so it doesn't break anything unexpectedly). We recommend setting up logrotate for the logfiles instead.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-default['rsyslog']['local_host_name']           = node['application']
+default['rsyslog']['local_host_name']           = nil
 default['rsyslog']['default_log_dir']           = '/var/log'
 default['rsyslog']['log_dir']                   = '/srv/rsyslog'
 default['rsyslog']['working_dir']               = '/var/spool/rsyslog'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 #
 
+default['rsyslog']['local_host_name']           = node['application']
 default['rsyslog']['default_log_dir']           = '/var/log'
 default['rsyslog']['log_dir']                   = '/srv/rsyslog'
 default['rsyslog']['working_dir']               = '/var/spool/rsyslog'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Installs and configures rsyslog'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '4.0.0'
+version           '4.0.1'
 
 recipe            'rsyslog', 'Installs rsyslog'
 recipe            'rsyslog::client', 'Sets up a client to log to a remote rsyslog server'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Installs and configures rsyslog'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '4.0.3'
+version           '4.0.4'
 
 recipe            'rsyslog', 'Installs rsyslog'
 recipe            'rsyslog::client', 'Sets up a client to log to a remote rsyslog server'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Installs and configures rsyslog'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '4.0.2'
+version           '4.0.3'
 
 recipe            'rsyslog', 'Installs rsyslog'
 recipe            'rsyslog::client', 'Sets up a client to log to a remote rsyslog server'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Installs and configures rsyslog'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '4.0.1'
+version           '4.0.2'
 
 recipe            'rsyslog', 'Installs rsyslog'
 recipe            'rsyslog::client', 'Sets up a client to log to a remote rsyslog server'

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -38,8 +38,8 @@ template "#{node['rsyslog']['config_prefix']}/rsyslog.d/35-server-per-host.conf"
 end
 
 # if we're a server we shouldn't be sending logs to a remote like a client
-file "#{node['rsyslog']['config_prefix']}/rsyslog.d/remote.conf" do
+file "#{node['rsyslog']['config_prefix']}/rsyslog.d/49-remote.conf" do
   action   :delete
   notifies :restart, "service[#{node['rsyslog']['service_name']}]"
-  only_if  { ::File.exist?("#{node['rsyslog']['config_prefix']}/rsyslog.d/remote.conf") }
+  only_if  { ::File.exist?("#{node['rsyslog']['config_prefix']}/rsyslog.d/49-remote.conf") }
 end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -82,15 +82,15 @@ describe 'rsyslog::server' do
     end
   end
 
-  context '/etc/rsyslog.d/remote.conf file' do
+  context '/etc/rsyslog.d/49-remote.conf file' do
     before do
       allow(File).to receive(:exist?).and_return(true)
     end
 
-    let(:file) { chef_run.file('/etc/rsyslog.d/remote.conf') }
+    let(:file) { chef_run.file('/etc/rsyslog.d/49-remote.conf') }
 
     it 'deletes the file' do
-      expect(chef_run).to delete_file('/etc/rsyslog.d/remote.conf')
+      expect(chef_run).to delete_file('/etc/rsyslog.d/49-remote.conf')
     end
 
     it 'notifies restarting the service' do
@@ -108,10 +108,10 @@ describe 'rsyslog::server' do
         end.converge(described_recipe)
       end
 
-      let(:file) { chef_run.file('/opt/local/etc/rsyslog.d/remote.conf') }
+      let(:file) { chef_run.file('/opt/local/etc/rsyslog.d/49-remote.conf') }
 
       it 'deletes the file' do
-        expect(chef_run).to delete_file('/opt/local/etc/rsyslog.d/remote.conf')
+        expect(chef_run).to delete_file('/opt/local/etc/rsyslog.d/49-remote.conf')
       end
 
       it 'notifies restarting the service' do

--- a/templates/default/35-server-per-host.conf.erb
+++ b/templates/default/35-server-per-host.conf.erb
@@ -58,5 +58,5 @@ news.notice             -?PerHostNewsNotice
 # Stop processing of all non-local messages. You can process remote messages
 # on levels less than 35.
 #
-:fromhost-ip,!isequal,"127.0.0.1" ~
+:fromhost-ip,!isequal,"127.0.0.1" stop
 <% end -%>

--- a/templates/default/rsyslog.conf.erb
+++ b/templates/default/rsyslog.conf.erb
@@ -7,6 +7,10 @@
 #
 #  Default logging rules can be found in /etc/rsyslog.d/50-default.conf
 #
+# Set hostname
+#
+$LocalHostName <%= node['rsyslog']['local_host_name'] %>
+#
 # Set max message size
 #
 $MaxMessageSize <%= node['rsyslog']['max_message_size'] %>

--- a/templates/default/rsyslog.conf.erb
+++ b/templates/default/rsyslog.conf.erb
@@ -9,7 +9,9 @@
 #
 # Set hostname
 #
+<% if node['rsyslog']['local_host_name'] -%>
 $LocalHostName <%= node['rsyslog']['local_host_name'] %>
+<% end %>
 #
 # Set max message size
 #

--- a/test/fixtures/rsyslog_test/recipes/server.rb
+++ b/test/fixtures/rsyslog_test/recipes/server.rb
@@ -1,8 +1,8 @@
 require 'fileutils'
-unless Dir.exist?("#{node['rsyslog']['config_prefix']}/rsyslog.d")
-  FileUtils.mkdir("#{node['rsyslog']['config_prefix']}/rsyslog.d")
+unless Dir.exist?("#{node['rsyslog']['config_prefix']}/49-rsyslog.d")
+  FileUtils.mkdir("#{node['rsyslog']['config_prefix']}/49-rsyslog.d")
 end
 
-FileUtils.touch("#{node['rsyslog']['config_prefix']}/rsyslog.d/remote.conf")
+FileUtils.touch("#{node['rsyslog']['config_prefix']}/rsyslog.d/49-remote.conf")
 
 include_recipe 'rsyslog::server'

--- a/test/integration/server/serverspec/server_spec.rb
+++ b/test/integration/server/serverspec/server_spec.rb
@@ -8,6 +8,6 @@ describe file('/etc/rsyslog.d/35-server-per-host.conf') do
   it { should be_file }
 end
 
-describe file('/etc/rsyslog.d/remote.conf') do
+describe file('/etc/rsyslog.d/49-remote.conf') do
   it { should_not be_file }
 end


### PR DESCRIPTION
The remote configuration file generated by `rsyslog::client` is called `49-remote.conf`.