### PR TITLE
Add support for permitted peer

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ See `attributes/default.rb` for default values.
 * `node['rsyslog']['tls_certificate_file']` - Path to TLS certificate file. Required for server, optional for clients.
 * `node['rsyslog']['tls_key_file']` - Path to TLS key file. Required for server, optional for clients.
 * `node['rsyslog']['tls_auth_mode']` - Value for `$InputTCPServerStreamDriverAuthMode`/`$ActionSendStreamDriverAuthMode`, determines whether client certs are validated. Defaults to `anon` (no validation).
+* `node['rsyslog']['tls_permitted_peer']` - Value for `ActionSendStreamDriverPermittedPeer`, it narrows the list of the allowed hosts. Works with TLS only. Defaults to `nil`.
 * `node['rsyslog']['use_local_ipv4']` - Whether or not to make use the remote local IPv4 address on cloud systems when searching for servers (where available).  Default is 'false'.
 * `node['rsyslog']['allow_non_local']` - Whether or not to allow non-local messages. If 'false', incoming messages are only allowed from 127.0.0.1. Default is 'false'.
 * `node['rsyslog']['custom_remote']` - Array of hashes for configuring custom remote server targets

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,6 +47,7 @@ default['rsyslog']['tls_ca_file']               = nil
 default['rsyslog']['tls_certificate_file']      = nil
 default['rsyslog']['tls_key_file']              = nil
 default['rsyslog']['tls_auth_mode']             = 'anon'
+default['rsyslog']['tls_permitted_peer']        = nil
 default['rsyslog']['use_local_ipv4']            = false
 default['rsyslog']['allow_non_local']           = false
 default['rsyslog']['custom_remote']             = [{}]

--- a/templates/default/49-remote.conf.erb
+++ b/templates/default/49-remote.conf.erb
@@ -16,6 +16,9 @@ $DefaultNetstreamDriverKeyFile <%= node['rsyslog']['tls_key_file'] %>
 $DefaultNetstreamDriver gtls
 $ActionSendStreamDriverMode 1
 $ActionSendStreamDriverAuthMode <%= node['rsyslog']['tls_auth_mode'] %>
+<% if node['rsyslog']['tls_permitted_peer'] -%>
+$ActionSendStreamDriverPermittedPeer <%= node['rsyslog']['tls_permitted_peer'] %>
+<% end -%>
 <% end -%>
 
 <% @servers.each do |server| -%>


### PR DESCRIPTION
`ActionSendStreamDriverPermittedPeer` is an option that allows us to narrow the list
of the hosts that we want to talk to. (Works with TLS only)

I compared the PR against 2.2 branch since I would like Chef 11 support. It could easily cherry picked and added to the master afterwards.