### PR TITLE
Make rsyslog only restart once

### DIFF
--- a/resources/file_input.rb
+++ b/resources/file_input.rb
@@ -39,7 +39,7 @@ action :create do
               'state_file' => log_name,
               'severity' => severity,
               'facility' => facility
-    notifies :restart, "service[#{node['rsyslog']['service_name']}]"
+    notifies :restart, "service[#{node['rsyslog']['service_name']}]", :delayed
   end
 
   service node['rsyslog']['service_name'] do


### PR DESCRIPTION
### Description

This change means that if multiple `file_input` resources are declared the `rsyslogd` service restarts only once (at the end of the Chef run). This is required on systemd based distros where systemd imposes a limit on how many times rsyslogd can restart within a certain time space. Currently these systems get failed Chef runs when introducing multiple new `file_input`'s.
### Issues Resolved

N/A
### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing (N/A).
- [x] New functionality has been documented in the README if applicable (N/A)
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
