### PR TITLE
Remove debugging log statement

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -31,8 +31,6 @@ directory "#{node['rsyslog']['config_prefix']}/rsyslog.d" do
   mode  '0755'
 end
 
-log node['rsyslog']['group']
-
 directory node['rsyslog']['working_dir'] do
   owner node['rsyslog']['user']
   group node['rsyslog']['group']


### PR DESCRIPTION
### Description

Removes an unnecessary log statement that gets executed no matter what. (Throws off count for # of resources updated). It's just logging a node attribute anyway, which can be retrieved later. Seems like a debugging line that got left in.
### Issues Resolved

None
### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
