### PR TITLE
adds configurable settings for file and directory permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ See `attributes/default.rb` for default values.
 - `node['rsyslog']['custom_remote']` - Array of hashes for configuring custom remote server targets
 - `node['rsyslog']['additional_directives']` - Hash of additional directives and their values to place in the main rsyslog config file
 - `node['rsyslog']['local_host_name']` -  permits to overwrite the system hostname with the one specified in the directive
+- `node['rsyslog']['directory_create_mode']` - Create permissions for directories. Default is 0755
+- `node['rsyslog']['file_create_mode']` - Create permissions for files. Default is 0644
 
 ## Recipes
 ### default

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -53,6 +53,8 @@ default['rsyslog']['use_local_ipv4']            = false
 default['rsyslog']['allow_non_local']           = false
 default['rsyslog']['custom_remote']             = [{}]
 default['rsyslog']['additional_directives'] = {}
+default['rsyslog']['directory_create_mode']     = '0755'
+default['rsyslog']['file_create_mode']          = '0644'
 
 # The most likely platform-specific attributes
 default['rsyslog']['service_name']              = 'rsyslog'

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -25,7 +25,7 @@ include_recipe 'rsyslog::default'
 directory node['rsyslog']['log_dir'] do
   owner    node['rsyslog']['user']
   group    node['rsyslog']['group']
-  mode     '0755'
+  mode     node['rsyslog']['directory_create_mode']
   recursive true
 end
 

--- a/templates/default/35-server-per-host.conf.erb
+++ b/templates/default/35-server-per-host.conf.erb
@@ -6,8 +6,9 @@ $ModLoad imrelp
 $InputRELPServerRun <%= node['rsyslog']['relp_port'] %>
 <% end -%>
 $DirGroup <%= node['rsyslog']['group'] %>
-$DirCreateMode 0755
+$DirCreateMode <%= node['rsyslog']['directory_create_mode'] %>
 $FileGroup <%= node['rsyslog']['group'] %>
+$FileCreateMode <%= node['rsyslog']['file_create_mode'] %>
 
 $template PerHostAuth,"<%= node['rsyslog']['log_dir'] %>/<%= node['rsyslog']['per_host_dir'] %>/auth.log"
 $template PerHostCron,"<%= node['rsyslog']['log_dir'] %>/<%= node['rsyslog']['per_host_dir'] %>/cron.log"


### PR DESCRIPTION
### Description

The default permissions for directories and files should be configurable as many systems require much stricter settings.
### Issues Resolved

Adds two extra settings

```
default['rsyslog']['directory_create_mode']     = '0755'
default['rsyslog']['file_create_mode']          = '0644'
```
### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
