### PR TITLE
Removed empty value from default custom_remote in attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -51,7 +51,7 @@ default['rsyslog']['tls_auth_mode']             = 'anon'
 default['rsyslog']['tls_permitted_peer']        = nil
 default['rsyslog']['use_local_ipv4']            = false
 default['rsyslog']['allow_non_local']           = false
-default['rsyslog']['custom_remote']             = [{}]
+default['rsyslog']['custom_remote']             = []
 default['rsyslog']['additional_directives'] = {}
 
 # The most likely platform-specific attributes

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -38,7 +38,7 @@ server_ips.each do |ip|
   rsyslog_servers << { 'server' => ip, 'port' => node['rsyslog']['port'], 'logs' => node['rsyslog']['logs_to_forward'], 'protocol' => node['rsyslog']['protocol'], 'remote_template' => node['rsyslog']['default_remote_template'] }
 end
 
-unless node['rsyslog']['custom_remote'].first.empty?
+unless node['rsyslog']['custom_remote'].empty? || node['rsyslog']['custom_remote'].first.empty?
   node['rsyslog']['custom_remote'].each do |server|
     if server['server'].nil?
       Chef::Application.fatal!('Found a custom_remote server with no IP. Check your custom_remote attribute definition!')


### PR DESCRIPTION
### Description

When checking to see if you add a 49-remote.conf file using custom_remotes attribute, the first value in the array is checked, but because Chef merges the attributes the first one will always be blank if you choose not to have a default custom_remote.

### Issues Resolved
Not having a default custom_remote but having one in a role/environment will now work correctly


### Check List

- [ ✔ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ✔ ] New functionality includes testing.
- [ ✔ ] New functionality has been documented in the README if applicable
- [ ✔ ]  All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

