### PR TITLE
CH-#123 - RSYSLOG COOKBOOK :: Extending Attributes in lieu of hardcoded values

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ See `attributes/default.rb` for default values.
 - `node['rsyslog']['max_message_size']` - Specify the maximum allowed message size. Default is 2k.
 - `node['rsyslog']['user']` - Who should own the configuration files and directories
 - `node['rsyslog']['group']` - Who should group-own the configuration files and directories
+- `node['rsyslog']['dir_owner']` - Who should own the log directories
+- `node['rsyslog']['dir_group']` - Who should group-own the log directories
+- `node['rsyslog']['file_create_mode']` - Mode that should be set when creating log files
+- `node['rsyslog']['dir_create_mode']` - Mode that should be set when creating log directories
+- `node['rsyslog']['umask']` - Specify the processes umask
 - `node['rsyslog']['defaults_file']` - The full path to the defaults/sysconfig file for the service.
 - `node['rsyslog']['service_name']` - The platform-specific name of the service
 - `node['rsyslog']['preserve_fqdn']` - Value of the `$PreserveFQDN` configuration directive in `/etc/rsyslog.conf`. Default is 'off' for compatibility purposes.
@@ -48,6 +53,7 @@ See `attributes/default.rb` for default values.
 - `node['rsyslog']['default_facility_logs']` - Hash containing log facilities and destinations used in `50-default.conf` template.
 - `node['rsyslog']['default_file_template']` - The name of a pre-defined log format template (ie - RSYSLOG_FileFormat), used for local log files.
 - `node['rsyslog']['default_remote_template']` - The name of a pre-defined log format template (ie - RSYSLOG_FileFormat), used for sending to remote servers.
+- `node['rsyslog']['templates']` - Allows a user to specify a dynamic filename and the format of the logs
 - `node['rsyslog']['rate_limit_interval']` - Value of the $SystemLogRateLimitInterval configuration directive in `/etc/rsyslog.conf`. Default is nil, leaving it to the platform default.
 - `node['rsyslog']['rate_limit_burst']` - Value of the $SystemLogRateLimitBurst configuration directive in `/etc/rsyslog.conf`. Default is nil, leaving it to the platform default.
 - `node['rsyslog']['action_queue_max_disk_space']` - Max amount of disk space the disk-assisted queue is allowed to use ([more info](http://www.rsyslog.com/doc/queues.html)).

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -62,6 +62,11 @@ default['rsyslog']['priv_seperation']           = false
 default['rsyslog']['priv_user']                 = nil
 default['rsyslog']['priv_group']                = nil
 default['rsyslog']['modules']                   = %w(imuxsock imklog)
+default['rsyslog']['file_create_mode']          = '0640'
+default['rsyslog']['dir_create_mode']           = '0755'
+default['rsyslog']['umask']                     = '0022'
+default['rsyslog']['dir_owner']                 = 'root'
+default['rsyslog']['dir_group']                 = 'adm'
 
 # platform specific attributes
 case node['platform']

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -52,8 +52,8 @@ default['rsyslog']['tls_permitted_peer']        = nil
 default['rsyslog']['use_local_ipv4']            = false
 default['rsyslog']['allow_non_local']           = false
 default['rsyslog']['custom_remote']             = []
-default['rsyslog']['additional_directives'] = {}
-default['rsyslog']['templates'] = %w()
+default['rsyslog']['additional_directives']     = {}
+default['rsyslog']['templates']                 = %w()
 
 # The most likely platform-specific attributes
 default['rsyslog']['service_name']              = 'rsyslog'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -53,7 +53,7 @@ default['rsyslog']['use_local_ipv4']            = false
 default['rsyslog']['allow_non_local']           = false
 default['rsyslog']['custom_remote']             = []
 default['rsyslog']['additional_directives'] = {}
-default['rsyslog']['templates'] = {}
+default['rsyslog']['templates'] = %w()
 
 # The most likely platform-specific attributes
 default['rsyslog']['service_name']              = 'rsyslog'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -53,6 +53,7 @@ default['rsyslog']['use_local_ipv4']            = false
 default['rsyslog']['allow_non_local']           = false
 default['rsyslog']['custom_remote']             = []
 default['rsyslog']['additional_directives'] = {}
+default['rsyslog']['templates'] = {}
 
 # The most likely platform-specific attributes
 default['rsyslog']['service_name']              = 'rsyslog'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Installs and configures rsyslog'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '5.0.1'
+version           '5.1.0'
 
 recipe            'rsyslog', 'Sets up rsyslog for local logging'
 recipe            'rsyslog::client', 'Sets up a client to log to a remote rsyslog server'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Installs and configures rsyslog'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '5.1.0'
+version           '5.0.2'
 
 recipe            'rsyslog', 'Sets up rsyslog for local logging'
 recipe            'rsyslog::client', 'Sets up a client to log to a remote rsyslog server'

--- a/templates/default/rsyslog.conf.erb
+++ b/templates/default/rsyslog.conf.erb
@@ -82,10 +82,10 @@ $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 # Additional Log templates
 #
 <% if node['rsyslog']['templates'] -%>
-<% node['rsyslog']['templates'].each_pair do |k,v| %>
-$<%= k %> <%= v %>
+  <% node['rsyslog']['templates'].each_pair do |k,v| %>
+    $<%= k %> <%= v %>
+  <% end %>
 <% end %>
-
 # Filter duplicated messages
 $RepeatedMsgReduction <%= node['rsyslog']['repeated_msg_reduction'] %>
 

--- a/templates/default/rsyslog.conf.erb
+++ b/templates/default/rsyslog.conf.erb
@@ -78,6 +78,14 @@ $ActionFileDefaultTemplate <%= node["rsyslog"]["default_file_template"] %>
 $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 <% end -%>
 
+#
+# Additional Log templates
+#
+<% if node['rsyslog']['templates'] -%>
+<% node['rsyslog']['templates'].each_pair do |k,v| %>
+$<%= k %> <%= v %>
+<% end %>
+
 # Filter duplicated messages
 $RepeatedMsgReduction <%= node['rsyslog']['repeated_msg_reduction'] %>
 

--- a/templates/default/rsyslog.conf.erb
+++ b/templates/default/rsyslog.conf.erb
@@ -6,8 +6,6 @@
 #     /usr/share/doc/rsyslog-doc/html/rsyslog_conf.html
 #
 #  Default logging rules can be found in /etc/rsyslog.d/50-default.conf
-# Umask should be set at the top of the file
-$Umask <%= node['rsyslog']['umask']%>
 #
 # Set hostname
 #
@@ -97,6 +95,7 @@ $WorkDirectory <%= node['rsyslog']['working_dir'] %>
 #
 # Set the default permissions for all log files.
 #
+$Umask <%= node['rsyslog']['umask'] %>
 $FileOwner <%= node['rsyslog']['user'] %>
 $FileGroup <%= node['rsyslog']['group'] %>
 $FileCreateMode <%= node['rsyslog']['file_create_mode'] %>

--- a/templates/default/rsyslog.conf.erb
+++ b/templates/default/rsyslog.conf.erb
@@ -6,6 +6,8 @@
 #     /usr/share/doc/rsyslog-doc/html/rsyslog_conf.html
 #
 #  Default logging rules can be found in /etc/rsyslog.d/50-default.conf
+# Umask should be set at the top of the file
+$Umask <%= node['rsyslog']['umask']%>
 #
 # Set hostname
 #
@@ -89,9 +91,11 @@ $WorkDirectory <%= node['rsyslog']['working_dir'] %>
 #
 $FileOwner <%= node['rsyslog']['user'] %>
 $FileGroup <%= node['rsyslog']['group'] %>
-$FileCreateMode 0640
-$DirCreateMode 0755
-$Umask 0022
+$FileCreateMode <%= node['rsyslog']['file_create_mode'] %>
+$DirOwner <%= node['rsyslog']['dir_owner'] %>
+$DirGroup <%= node['rsyslog']['dir_group'] %>
+$DirCreateMode <%= node['rsyslog']['dir_create_mode'] %>
+
 <% if node['rsyslog']['priv_seperation'] %>
 $PrivDropToUser <%= node['rsyslog']['priv_user'] || node['rsyslog']['user'] %>
 $PrivDropToGroup <%= node['rsyslog']['priv_group'] || node['rsyslog']['group'] %>

--- a/templates/default/rsyslog.conf.erb
+++ b/templates/default/rsyslog.conf.erb
@@ -76,11 +76,11 @@ $ActionFileDefaultTemplate <%= node["rsyslog"]["default_file_template"] %>
 $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 <% end -%>
 
+<% if node['rsyslog']['templates'] && !node['rsyslog']['templates'].empty? -%>
+<% [*node['rsyslog']['templates']].each do |template| %>
 #
 # Additional Log templates
 #
-<% if node['rsyslog']['templates'] && !node['rsyslog']['templates'].empty? -%>
-<% [*node['rsyslog']['templates']].each do |template| %>
 $Template <%= template %>
 <% end %>
 <% end %>

--- a/templates/default/rsyslog.conf.erb
+++ b/templates/default/rsyslog.conf.erb
@@ -81,10 +81,10 @@ $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 #
 # Additional Log templates
 #
-<% if node['rsyslog']['templates'] -%>
-  <% node['rsyslog']['templates'].each_pair do |k,v| %>
-    $<%= k %> <%= v %>
-  <% end %>
+<% if node['rsyslog']['templates'] && !node['rsyslog']['templates'].empty? -%>
+<% [*node['rsyslog']['templates']].each do |template| %>
+$Template <%= template %>
+<% end %>
 <% end %>
 # Filter duplicated messages
 $RepeatedMsgReduction <%= node['rsyslog']['repeated_msg_reduction'] %>


### PR DESCRIPTION
### Description

Removes hardcoded values of $Umask, $FileCreateMode and $DirCreateMode. They can now be set using the attribute.
Added attributes for $DirOwner, $DirGroup and $Templates. These can now be set using attributes.

### Issues Resolved

https://github.com/chef-cookbooks/rsyslog/issues/123

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

