### PR TITLE
rsyslog package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ See `attributes/default.rb` for default values.
 - `node['rsyslog']['dir_create_mode']` - Mode that should be set when creating log directories
 - `node['rsyslog']['umask']` - Specify the processes umask
 - `node['rsyslog']['defaults_file']` - The full path to the defaults/sysconfig file for the service.
+- `node['rsyslog']['package_name']` - Specify rsyslog package name
 - `node['rsyslog']['service_name']` - The platform-specific name of the service
 - `node['rsyslog']['preserve_fqdn']` - Value of the `$PreserveFQDN` configuration directive in `/etc/rsyslog.conf`. Default is 'off' for compatibility purposes.
 - `node['rsyslog']['high_precision_timestamps']` - Enable high precision timestamps, instead of the "old style" format. Default is 'false'.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -56,6 +56,7 @@ default['rsyslog']['additional_directives']     = {}
 default['rsyslog']['templates']                 = %w()
 
 # The most likely platform-specific attributes
+default['rsyslog']['package_name']              = 'rsyslog'
 default['rsyslog']['service_name']              = 'rsyslog'
 default['rsyslog']['user']                      = 'root'
 default['rsyslog']['group']                     = 'adm'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,12 +17,12 @@
 # limitations under the License.
 #
 
-package 'rsyslog'
-package 'rsyslog-relp' if node['rsyslog']['use_relp']
+package node['rsyslog']['package_name']
+package "#{node['rsyslog']['package_name']}-relp" if node['rsyslog']['use_relp']
 
 if node['rsyslog']['enable_tls'] && node['rsyslog']['tls_ca_file']
   raise "Recipe rsyslog::default can not use 'enable_tls' with protocol '#{node['rsyslog']['protocol']}' (requires 'tcp')" unless node['rsyslog']['protocol'] == 'tcp'
-  package 'rsyslog-gnutls'
+  package "#{node['rsyslog']['package_name']}-gnutls"
 end
 
 directory "#{node['rsyslog']['config_prefix']}/rsyslog.d" do


### PR DESCRIPTION
Signed-off-by: Aivaras Laimikis <aivaraslaimikis@gmail.com>

### Description

 Some distribution supports more than one rsyslog package version. Red Hat 5 and 6 have default rsyslog package and additionally rsyslog5 and rsyslog7 with all dependencies. So this change allows to use different (usually newer) rsyslog packages with rsyslog cookbook.

### Issues Resolved

https://github.com/chef-cookbooks/rsyslog/issues/125

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
