### PR TITLE
Optional creation of default configuration file 50-default.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ See `attributes/default.rb` for default values.
 - `node['rsyslog']['custom_remote']` - Array of hashes for configuring custom remote server targets
 - `node['rsyslog']['additional_directives']` - Hash of additional directives and their values to place in the main rsyslog config file
 - `node['rsyslog']['local_host_name']` - permits to overwrite the system hostname with the one specified in the directive
+- `node['rsyslog']['default_conf_file']` - If false it skips the creation of default configuration file 50-default.conf
 
 ## Recipes
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -54,6 +54,7 @@ default['rsyslog']['allow_non_local']           = false
 default['rsyslog']['custom_remote']             = []
 default['rsyslog']['additional_directives']     = {}
 default['rsyslog']['templates']                 = %w()
+default['rsyslog']['default_conf_file']         = true
 
 # The most likely platform-specific attributes
 default['rsyslog']['package_name']              = 'rsyslog'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -60,7 +60,7 @@ template "#{node['rsyslog']['config_prefix']}/rsyslog.d/50-default.conf" do
   mode    '0644'
   notifies :run, 'execute[validate_config]'
   notifies :restart, "service[#{node['rsyslog']['service_name']}]"
-end
+end unless node['rsyslog']['default_conf_file'] == false
 
 # syslog needs to be stopped before rsyslog can be started on RHEL versions before 6.0
 if platform_family?('rhel') && node['platform_version'].to_i < 6


### PR DESCRIPTION
- Added a boolean attribute node['rsyslog']['default_conf_file']
  which is by default true.
- When node['rsyslog']['default_conf_file'] is false, the default
  configuration file 50-default.conf is not created, otherwise the
  behaviour is unchanged.

### Description

Enable cookbooks using this one to skip the creation of default configuration file 50-default.conf

### Issues Resolved

In some case the default configuration file 50-default.conf is not necessary; when another cookbook removes it then that file is created (by the rsyslog cookbook) and removed (by the other cookbook) at each run of chef-client. This causes rsyslog to restart at each run of chef-client. This issue can be solved by making the creation of the default configuration file 50-default.conf optional.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
