### PR TITLE
Let permissions be configured through attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -69,6 +69,9 @@ default['rsyslog']['dir_create_mode']           = '0755'
 default['rsyslog']['umask']                     = '0022'
 default['rsyslog']['dir_owner']                 = 'root'
 default['rsyslog']['dir_group']                 = 'adm'
+default['rsyslog']['config_files']['owner']     = 'root'
+default['rsyslog']['config_files']['group']     = 'root'
+default['rsyslog']['config_files']['mode']      = '0644'
 
 # platform specific attributes
 case node['platform']

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache-2.0'
 description       'Installs and configures rsyslog'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '6.0.1'
+version           '6.0.2'
 
 recipe            'rsyslog', 'Sets up rsyslog for local logging'
 recipe            'rsyslog::client', 'Sets up a client to log to a remote rsyslog server'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -46,18 +46,18 @@ end
 # include of things in /etc/rsyslog.d/*
 template "#{node['rsyslog']['config_prefix']}/rsyslog.conf" do
   source  'rsyslog.conf.erb'
-  owner   'root'
-  group   'root'
-  mode    '0644'
+  owner   node['rsyslog']['config_files']['owner']
+  group   node['rsyslog']['config_files']['group']
+  mode    node['rsyslog']['config_files']['mode']
   notifies :run, 'execute[validate_config]'
   notifies :restart, "service[#{node['rsyslog']['service_name']}]"
 end
 
 template "#{node['rsyslog']['config_prefix']}/rsyslog.d/50-default.conf" do
   source  '50-default.conf.erb'
-  owner   'root'
-  group   'root'
-  mode    '0644'
+  owner   node['rsyslog']['config_files']['owner']
+  group   node['rsyslog']['config_files']['group']
+  mode    node['rsyslog']['config_files']['mode']
   notifies :run, 'execute[validate_config]'
   notifies :restart, "service[#{node['rsyslog']['service_name']}]"
 end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -31,9 +31,9 @@ end
 
 template "#{node['rsyslog']['config_prefix']}/rsyslog.d/35-server-per-host.conf" do
   source   '35-server-per-host.conf.erb'
-  owner    'root'
-  group    'root'
-  mode     '0644'
+  owner    node['rsyslog']['config_files']['owner']
+  group    node['rsyslog']['config_files']['group']
+  mode     node['rsyslog']['config_files']['mode']
   notifies :run, 'execute[validate_config]'
   notifies :restart, "service[#{node['rsyslog']['service_name']}]"
 end

--- a/resources/file_input.rb
+++ b/resources/file_input.rb
@@ -25,18 +25,18 @@ property :cookbook_source, String, default: 'rsyslog'
 property :template_source, String, default: 'file-input.conf.erb'
 
 action :create do
-  log_name = name
-  template "/etc/rsyslog.d/#{priority}-#{name}.conf" do
+  log_name = new_resource.name
+  template "/etc/rsyslog.d/#{new_resource.priority}-#{new_resource.name}.conf" do
     mode '0664'
     owner node['rsyslog']['user']
     group node['rsyslog']['group']
-    source template_source
-    cookbook cookbook_source
-    variables 'file_name' => file,
+    source new_resource.template_source
+    cookbook new_resource.cookbook_source
+    variables 'file_name' => new_resource.file,
               'tag' => log_name,
               'state_file' => log_name,
-              'severity' => severity,
-              'facility' => facility
+              'severity' => new_resource.severity,
+              'facility' => new_resource.facility
     notifies :restart, "service[#{node['rsyslog']['service_name']}]", :delayed
   end
 


### PR DESCRIPTION
### Description
Convert some template resource properties for config files to attributes to they can be configured elsewhere.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
