### PR TITLE
Skip search if ['rsyslog']['server_search'] is empty

### DIFF
--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -29,7 +29,7 @@ results = search(:node, node['rsyslog']['server_search']).map do |server|
     ipaddress = server['cloud']['local_ipv4']
   end
   ipaddress
-end
+end unless node['rsyslog']['server_search'].to_s.empty?
 server_ips = Array(node['rsyslog']['server_ip']) + Array(results)
 
 rsyslog_servers = []


### PR DESCRIPTION
Signed-off-by: Joe Nuspl <nuspl@nvwls.com>

### Description

Skip `search` if the search string is empty.

### Issues Resolved

For environments that specify `node['rsyslog']['server_ip']` instead of using `search`, you be able set `node['rsyslog']['server_search']` to `nil` to not perform the `search` instead of having to specify a dummy search such as `'role:DOES_NOT_EXIST'`

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
